### PR TITLE
Fix ancombc regex and runsheet names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated file associations table to include outputs of Final_outputs subdirectories
 
 
+### Fixed
+
+- Fixed regex pattern in ANCOMBC scripts so factor conditions with underscores are parsed correctly
+- Fixed runsheet handling so params.input_file paths with spaces no longer break processes
+
 <br>
 
 ---

--- a/workflow_code/bin/pairwise_ancombc1.R
+++ b/workflow_code/bin/pairwise_ancombc1.R
@@ -577,7 +577,7 @@ volcano_plots <- map(comp_names, function(comparison){
   sub_res_df <- merged_stats_df %>% 
     select(!!feature, all_of(comp_col)) %>% drop_na()
   colnames(sub_res_df) <- str_replace_all(colnames(sub_res_df),
-                                          pattern = "(.+)_.+", 
+                                          pattern = "(.+)_\\(.+\\)v\\(.+\\)$", 
                                           replacement = "\\1")
   
   p_val <- 0.1

--- a/workflow_code/bin/pairwise_ancombc2.R
+++ b/workflow_code/bin/pairwise_ancombc2.R
@@ -705,7 +705,7 @@ volcano_plots <- map(uniq_comps, function(comparison){
   sub_res_df <- res_df %>% 
     select(!!feature, all_of(comp_col))
   colnames(sub_res_df) <- str_replace_all(colnames(sub_res_df),
-                                          pattern = "(.+)_.+", 
+                                          pattern = "(.+)_\\(.+\\)v\\(.+\\)$", 
                                           replacement = "\\1")
   
   p_val <- 0.1

--- a/workflow_code/modules/ancombc.nf
+++ b/workflow_code/modules/ancombc.nf
@@ -38,7 +38,7 @@ process ANCOMBC {
         fi
         
         \${script_name} \\
-                  --metadata-table '${metadata}' \\
+                  --metadata-table ${metadata} \\
                   --feature-table '${feature_table}' \\
                   --taxonomy-table '${taxonomy}' \\
                   --group '${meta.group}' \\

--- a/workflow_code/modules/deseq.nf
+++ b/workflow_code/modules/deseq.nf
@@ -23,7 +23,7 @@ process DESEQ  {
     script:
         """
         run_deseq2.R \\
-                  --metadata-table '${metadata}' \\
+                  --metadata-table ${metadata} \\
                   --feature-table '${feature_table}' \\
                   --taxonomy-table '${taxonomy_table}' \\
                   --group '${meta.group}' \\

--- a/workflow_code/modules/diversity.nf
+++ b/workflow_code/modules/diversity.nf
@@ -30,7 +30,7 @@ process ALPHA_DIVERSITY {
     script:
         """
         alpha_diversity.R \\
-                  --metadata-table '${metadata}' \\
+                  --metadata-table ${metadata} \\
                   --feature-table '${feature_table}' \\
                   --taxonomy-table '${taxonomy_table}' \\
                   --group '${meta.group}' \\
@@ -73,7 +73,7 @@ process BETA_DIVERSITY {
     script:
         """
         beta_diversity.R \\
-                  --metadata-table '${metadata}' \\
+                  --metadata-table ${metadata} \\
                   --feature-table '${feature_table}' \\
                   --taxonomy-table '${taxonomy_table}' \\
                   --group '${meta.group}' \\

--- a/workflow_code/modules/run_dada.nf
+++ b/workflow_code/modules/run_dada.nf
@@ -44,7 +44,7 @@ process RUN_R_TRIM {
                            "${params.left_maxEE}" \
                            "${params.right_maxEE}" \
                            "\${TRIM_PRIMERS}" \
-                           "${sample_IDs_file}" \
+                           ${sample_IDs_file} \
                            "Trimmed_Sequence_Data/" \
                            "Filtered_Sequence_Data/" \
                            "${params.primer_trimmed_R1_suffix}" \
@@ -69,7 +69,7 @@ process RUN_R_TRIM {
                           "${params.left_trunc}" \
                           "${params.left_maxEE}" \
                           "\${TRIM_PRIMERS}" \
-                          "${sample_IDs_file}" \
+                          ${sample_IDs_file} \
                           "Trimmed_Sequence_Data/" \
                           "Filtered_Sequence_Data/" \
                           "${params.primer_trimmed_R1_suffix}" \
@@ -128,7 +128,7 @@ process RUN_R_NOTRIM {
                             "${params.left_maxEE}" \
                             "${params.right_maxEE}" \
                             "\${TRIM_PRIMERS}" \
-                            "${sample_IDs_file}" \
+                            ${sample_IDs_file} \
                             "raw_reads/" \
                             "Filtered_Sequence_Data/" \
                             "${raw_read_suffix[0]}" \
@@ -151,7 +151,7 @@ process RUN_R_NOTRIM {
                            "${params.left_trunc}" \
                            "${params.left_maxEE}" \
                            "\${TRIM_PRIMERS}" \
-                           "${sample_IDs_file}" \
+                           ${sample_IDs_file} \
                            "raw_reads/" \
                            "Filtered_Sequence_Data/" \
                            "${raw_read_suffix[0]}" \

--- a/workflow_code/modules/taxonomy_plots.nf
+++ b/workflow_code/modules/taxonomy_plots.nf
@@ -28,7 +28,7 @@ process PLOT_TAXONOMY  {
     script:
         """
         plot_taxonomy.R \\
-                  --metadata-table '${metadata}' \\
+                  --metadata-table ${metadata} \\
                   --feature-table '${feature_table}' \\
                   --taxonomy-table '${taxonomy_table}' \\
                   --group '${meta.group}' \\


### PR DESCRIPTION
- Fix issue where underscores in factor conditions would cause an error in ANCOMBC scripts
- Fix issue where spaces in runsheet name would cause error in several processes